### PR TITLE
chore: Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # NPM Package Configuration
+  - package-ecosystem: "npm"
+    directory: "/"
+    # Labels to set on pull requests
+    labels:
+      - "npm"
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "npm: "
+      prefix: "npm"
+    groups:
+      # CSS Bundler Dependencies
+      css-bundling:
+        patterns:
+          - "postcss*"
+          - "autoprefixer"
+          - "tailwind*"
+      # Linter Dependencies
+      linter:
+        patterns:
+          - "eslint*"
+          - "@typescript*"
+      # Storybook Dependencies
+      storybook:
+        patterns:
+          - "*storybook*"
+      # Development Dependencies
+      dev-dependencies:
+        patterns:
+          - "*@types/*"
+          - "tsup"
+          - "typescript"
+          - "*prettier*"
+      # Javascript Dependencies
+      js:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

- Adds `Dependabot` configuration for automated dependency updates.
- Set up dependencies in groups for easy management.

## Why

- Keep project up to date with latest dependency releases.
- Keep dependencies isolated in small groups to easily merge the ones which have no impact in the project logic, while keeping the critical dependencies, with higher risk of introducing bugs in the codebase, isolated in their own PRs.